### PR TITLE
Require dev cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,9 +124,6 @@
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
         "patches": {
-            "drupal/rabbit_hole": {
-                "trusted": "https://www.drupal.org/files/issues/trusted-2843564-1.patch"
-            },
             "drupal/remote_stream_wrapper": {
               "entity_browser": "https://www.drupal.org/files/issues/entity-browser-widget-2775505-7.patch",
               "custom require hack": "https://raw.githubusercontent.com/stevector/nerdologues-d8/master/patches/remote_stream_wrapper_require.patch?testing"

--- a/composer.json
+++ b/composer.json
@@ -57,13 +57,9 @@
     },
 
     "require-dev": {
-        "behat/mink": "~1.7",
-        "behat/mink-goutte-driver": "~1.2",
         "mikey179/vfsStream": "~1.2",
-        "symfony/css-selector": "~2.8",
         "drush-ops/behat-drush-endpoint": "*",
         "drupal/drupal-extension": "dev-master",
-        "drupal/drupal-driver": "dev-master",
         "drupal/coder": "^8.2.0-beta1",
         "squizlabs/php_codesniffer": "2.0.*@dev",
         "knplabs/friendly-contexts": "^0.7.0",

--- a/composer.json
+++ b/composer.json
@@ -59,8 +59,6 @@
     "require-dev": {
         "behat/mink": "~1.7",
         "behat/mink-goutte-driver": "~1.2",
-        "jcalderonzumba/gastonjs": "~1.0.2",
-        "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
         "mikey179/vfsStream": "~1.2",
         "symfony/css-selector": "~2.8",
         "drush-ops/behat-drush-endpoint": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43281d21400ade422df50636c35ff92a",
+    "content-hash": "077cc3391e1ffc957721709cd6d98414",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3569,8 +3569,7 @@
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": []
+                }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a73ef37f29776015b9186fa7cf6ec09",
+    "content-hash": "43281d21400ade422df50636c35ff92a",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -1692,16 +1692,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.6.7",
+            "version": "8.6.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "e0a09bda1da7552204464894811a59387608c9f9"
+                "reference": "cac12e0ec19d5c6fa53778522b3ff4c542f86c8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/e0a09bda1da7552204464894811a59387608c9f9",
-                "reference": "e0a09bda1da7552204464894811a59387608c9f9",
+                "url": "https://api.github.com/repos/drupal/core/zipball/cac12e0ec19d5c6fa53778522b3ff4c542f86c8d",
+                "reference": "cac12e0ec19d5c6fa53778522b3ff4c542f86c8d",
                 "shasum": ""
             },
             "require": {
@@ -1927,7 +1927,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2019-01-16T23:30:03+00:00"
+            "time": "2019-02-08T12:21:40+00:00"
         },
         {
             "name": "drupal/ctools",
@@ -5309,6 +5309,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {
@@ -9031,16 +9032,16 @@
         },
         {
             "name": "drupal/drupal-driver",
-            "version": "dev-master",
+            "version": "v2.0.0-alpha6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhedstrom/DrupalDriver.git",
-                "reference": "395de88a9ea73b0dcaa89a3ffc2c29248cccc4aa"
+                "reference": "732f2c7b3c262487bed0876a209e5326bc3935e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/395de88a9ea73b0dcaa89a3ffc2c29248cccc4aa",
-                "reference": "395de88a9ea73b0dcaa89a3ffc2c29248cccc4aa",
+                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/732f2c7b3c262487bed0876a209e5326bc3935e4",
+                "reference": "732f2c7b3c262487bed0876a209e5326bc3935e4",
                 "shasum": ""
             },
             "require": {
@@ -9086,7 +9087,7 @@
                 "test",
                 "web"
             ],
-            "time": "2018-09-21T19:08:45+00:00"
+            "time": "2018-12-18T23:21:10+00:00"
         },
         {
             "name": "drupal/drupal-extension",
@@ -10067,7 +10068,6 @@
         "drupal/timeperiod": 20,
         "drupal/config_readonly": 10,
         "drupal/drupal-extension": 20,
-        "drupal/drupal-driver": 20,
         "squizlabs/php_codesniffer": 20
     },
     "prefer-stable": true,


### PR DESCRIPTION
Removing verbosity from require-dev section that implies a more opinionated set of dependencies than are actually needed