### PR TITLE
reference orb by hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
 
 orbs:
   cypress: cypress-io/cypress@1
-  playground: fauxalgore/playground@dev:12
+  playground: fauxalgore/playground@dev:55fe146
   pantheon: stevector/pantheon@dev:stevector
 
 jobs:


### PR DESCRIPTION
Testing that orbs can be pulled in by commit hash. Published from https://circleci.com/gh/fauxalgore/orbs/17